### PR TITLE
Fixed Observable.TakeWhile & Observable.Where Method.

### DIFF
--- a/System.Reactive/System.Reactive.Linq/Observable.cs
+++ b/System.Reactive/System.Reactive.Linq/Observable.cs
@@ -2258,7 +2258,12 @@ namespace System.Reactive.Linq
 				throw new ArgumentNullException ("predicate");
 
 			bool stopped = false;
-			return source.Where ((s, i) => !stopped && (stopped = !predicate (s, i)));
+            return source.Where((s, i) => 
+            {
+                if (stopped) return false;
+                stopped = !predicate(s, i); 
+                return !stopped; 
+            });
 		}
 		
 		public static Plan<TResult> Then<TSource, TResult> (
@@ -2833,7 +2838,7 @@ namespace System.Reactive.Linq
 			return new ColdObservableEach<TSource> (sub => {
 			// ----
 			int idx = 0;
-			return source.Subscribe ((s) => { if (predicate (s, idx++)) sub.OnNext (s); });
+			return source.Subscribe ((s) => { if (predicate (s, idx++)) sub.OnNext (s); },ex => sub.OnError(ex),() => sub.OnCompleted());
 			// ----
 			}, DefaultColdScheduler);
 		}


### PR DESCRIPTION
Observable.Where method ignored "OnCompleted" && "OnError".
In Observable.TakeWhile methods, evaluation was wrong.

//--Problem--

var s1 = new Subject<int>();

var source = s1.TakeWhile(i => i < 4);

source.Subscribe(i => Console.WriteLine("OnNext : " + i), i => Console.WriteLine("OnError"), () => Console.WriteLine("OnCompleted"));

s1.OnNext(1);
s1.OnNext(2);
s1.OnNext(3);
s1.OnNext(4);
s1.OnNext(5);
s1.OnNext(1);

s1.OnCompleted();

//--Actual Result--

OnNext : 4

//--Expect Result--

OnNext : 1
OnNext : 2
OnNext : 3
OnCompleted
